### PR TITLE
Deprecate using `id` for custom primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Deprecate using `id` for primary key when an application has a custom primary key.
+
+    Previously the `id` method had a double meaning. In an application that uses `id` as the primary key this would return the `id` attribute. However, applications with custom primary keys would return the custom key value even if the table had an `id` attribute. This behavior is now deprecated.
+
+    Applications that use `id` as the primary key require no changes. Applications that do use custom primary keys will need to update their application to call the new method `primary_key_value`. Applications can opt into the new behavior by setting `config.active_record.use_id_as_attribute = true`.
+
+    Mapping of old methods to new methods:
+
+    * `id` => `primary_key_value`
+    * `id=(value)` => `primary_key_value=(value)`
+    * `id?` => `primary_key_value?`
+    * `id_was` => `primary_key_was`
+    * `id_in_database` => `primary_key_in_database`
+    * `id_before_type_cast` => `primary_key_before_type_cast`
+
+    This change will provide new public APIs for accessing custom primary keys which will restore the ability to query the `id` column if it exists and is not the primary key.
+
+    *Eileen M. Uchitelle*
+
 *   `after_commit` callbacks defined on models now execute in the correct order.
 
     ```ruby

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -440,6 +440,13 @@ module ActiveRecord
   singleton_class.attr_accessor :yaml_column_permitted_classes
   self.yaml_column_permitted_classes = [Symbol]
 
+  ##
+  # :singleton-method:
+  # Application configuration to always treat +id+ as an attribute rather than
+  # a primary key. When true, use +primary_key_value+ to get the primary key.
+  singleton_class.attr_accessor :use_id_as_attribute
+  self.use_id_as_attribute = false
+
   def self.marshalling_format_version
     Marshalling.format_version
   end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -156,7 +156,7 @@ module ActiveRecord
 
           if source_reflection.options[:counter_cache] && method != :destroy
             counter = source_reflection.counter_cache_column
-            klass.decrement_counter counter, records.map(&:id)
+            klass.decrement_counter counter, records.map(&:primary_key_value)
           end
 
           if through_reflection.collection? && update_through_counter?(method)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -409,7 +409,7 @@ module ActiveRecord
       def attributes_for_create(attribute_names)
         attribute_names &= self.class.column_names
         attribute_names.delete_if do |name|
-          (pk_attribute?(name) && id.nil?) ||
+          (pk_attribute?(name) && primary_key_value.nil?) ||
             column_for_attribute(name).virtual?
         end
       end

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -10,25 +10,70 @@ module ActiveRecord
       # Returns this record's primary key value wrapped in an array if one is
       # available.
       def to_key
-        key = id
+        key = primary_key_value
         [key] if key
       end
 
-      # Returns the primary key column's value.
+      # If +use_id_as_attribute+ is set, this method will return the
+      # +id+ attribute from the database. If it is not set, it returns
+      # the primary key column's value. The latter is deprecated.
       def id
-        return _read_attribute(@primary_key) unless @primary_key.is_a?(Array)
+        if ActiveRecord.use_id_as_attribute
+          _read_attribute("id")
+        else
+          if primary_key_is_not_id?
+            # deprecation
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              You are using a custom primary key and calling `id` to access it.
 
-        @primary_key.map { |pk| _read_attribute(pk) }
+              Returning the primary key's value when calling `id` is deprecated. In Rails
+              7.2 this method will return the value from the database for the `id` attribute
+              if defined. To get the primary key's value, use `primary_key_value`.
+            MSG
+          end
+
+          primary_key_value
+        end
+      end
+
+      # Returns the primary key column's value.
+      def primary_key_value
+        if @primary_key.is_a?(Array)
+          @primary_key.map { |pk| _read_attribute(pk) }
+        else
+          _read_attribute(@primary_key)
+        end
       end
 
       def primary_key_values_present? # :nodoc:
-        return id.all? if self.class.composite_primary_key?
+        return primary_key_value.all? if self.class.composite_primary_key?
 
-        !!id
+        !!primary_key_value
+      end
+
+      # If +use_id_as_attribute+ is set, this method will set the
+      # +id+ attribute in the database. If it is not set, it sets
+      # the primary key column's value. The latter is deprecated.
+      def id=(value)
+        if ActiveRecord.use_id_as_attribute
+          _write_attribute("id", value)
+        else
+          if primary_key_is_not_id?
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              You are using a custom primary key and calling `id=` to set it.
+
+              Setting the primary key's value when calling `id=` is deprecated. In Rails
+              7.2 this method will set the value from the database for the `id` attribute
+              if defined. To set the primary key's value, use `primary_key_value=`.
+            MSG
+          end
+
+          self.primary_key_value = value
+        end
       end
 
       # Sets the primary key column's value.
-      def id=(value)
+      def primary_key_value=(value)
         if self.class.composite_primary_key?
           @primary_key.zip(value) { |attr, value| _write_attribute(attr, value) }
         else
@@ -36,31 +81,135 @@ module ActiveRecord
         end
       end
 
-      # Queries the primary key column's value.
+      # If +use_id_as_attribute+ is set, this method will query the
+      # +id+ column's value. Otherwise this will query the primary key
+      # column's value. If you are using a custom primary key, use the
+      # +primary_key_value?+ method to avoid the deprecation warning.
       def id?
+        if ActiveRecord.use_id_as_attribute
+          query_attribute(ID_COLUMN)
+        else
+          if primary_key_is_not_id?
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Calling `id?` for a custom primary key is deprecated. In
+              7.2 this method will query the `id` column's value. To
+              query the primary key column's value use `primary_key_value?`
+            MSG
+          end
+
+          primary_key_value?
+        end
+      end
+
+      # Queries the primary key column's value.
+      def primary_key_value?
         query_attribute(@primary_key)
       end
 
-      # Returns the primary key column's value before type cast.
+      # If +use_id_as_attribute+ is set, this method will return the
+      # +id+ column's value before type casting. Otherwise this will
+      # return the primary key's value before type casting. If you are
+      # using a custom primary key, use the +primary_key_before_type_cast+
+      # method to avoid the deprecation warning.
       def id_before_type_cast
+        if ActiveRecord.use_id_as_attribute
+          attribute_before_type_cast(ID_COLUMN)
+        else
+          if primary_key_is_not_id?
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Calling `primary_key_before_type_cast` for a custom primary key is
+              deprecated. In 7.2 this method will return the value before type casting
+              for the `id` attribute. To get the value before type casting for the primary
+              key's use `primary_key_before_type_cast`.
+            MSG
+          end
+
+          primary_key_before_type_cast
+        end
+      end
+
+      # Returns the primary key column's value before type cast.
+      def primary_key_before_type_cast
         attribute_before_type_cast(@primary_key)
       end
 
-      # Returns the primary key column's previous value.
+      # If +use_id_as_attribute+ is set, this method will return the
+      # +id+ column's previous value. Otherwise this will return the
+      # primary key's previous value. If you are using a custom primary
+      # key, use the +primary_key_was+ method instead to avoid the
+      # deprecation warning.
       def id_was
+        if ActiveRecord.use_id_as_attribute
+          attribute_was(ID_COLUMN)
+        else
+          if primary_key_is_not_id?
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Calling `id_was` for a custom primary key is deprecated. In 7.2
+              this method will return the previous value for the `id` attribute. To
+              get the primary key's previous value use `primary_key_was`.
+            MSG
+          end
+
+          primary_key_was
+        end
+      end
+
+      # Returns the primary key column's previous value.
+      def primary_key_was
         attribute_was(@primary_key)
       end
 
-      # Returns the primary key column's value from the database.
+      # If +use_id_as_attribute+ is set, this method will return the
+      # +id+ attribute in the database. Otherwise this will return the
+      # primary key value in the database. If you are using a custom primary
+      # key, use the +primary_key_in_database+ method instead to avoid the
+      # deprecation warning.
       def id_in_database
+        if ActiveRecord.use_id_as_attribute
+          attribute_in_database(ID_COLUMN)
+        else
+          if primary_key_is_not_id?
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Calling `id_in_database` for a custom primary key is deprecated. In 7.2
+              this method will return the database value for the `id` attribute. To
+              get the primary key from the database use `primary_key_in_database`.
+            MSG
+          end
+
+          primary_key_in_database
+        end
+      end
+
+      # Returns the primary key column's value from the database.
+      def primary_key_in_database
         attribute_in_database(@primary_key)
       end
 
       def id_for_database # :nodoc:
+        if ActiveRecord.use_id_as_attribute
+          @attributes[ID_COLUMN].value_for_database
+        else
+          if primary_key_is_not_id?
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Calling `id_for_database` for a custom primary key is deprecated. In 7.2
+              this method will use the database value for the `id` attribute. To
+              use the primary key value for the database use `primary_key_for_database`.
+            MSG
+          end
+
+          primary_key_for_database
+        end
+      end
+
+      def primary_key_for_database # :nodoc:
         @attributes[@primary_key].value_for_database
       end
 
       private
+        def primary_key_is_not_id?
+          @primary_key != "id" #|| @primary_key != "ID"
+        end
+
         def attribute_method?(attr_name)
           attr_name == "id" || super
         end
@@ -68,6 +217,7 @@ module ActiveRecord
         module ClassMethods
           ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database id_for_database).to_set
           PRIMARY_KEY_NOT_SET = BasicObject.new
+          ID_COLUMN = "id"
 
           def instance_method_already_implemented?(method_name)
             super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -29,6 +29,7 @@ module ActiveRecord
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name
 
+        # TODO: need to fix this as part of work
         return @attributes.fetch_value(name, &block) unless name == "id" && @primary_key
 
         if self.class.composite_primary_key?

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -555,7 +555,7 @@ module ActiveRecord
       super ||
         comparison_object.instance_of?(self.class) &&
         primary_key_values_present? &&
-        comparison_object.id == id &&
+        comparison_object.primary_key_value == primary_key_value &&
         !comparison_object.new_record?
     end
     alias :eql? :==
@@ -563,7 +563,7 @@ module ActiveRecord
     # Delegates to id in order to allow two records of the same type and id to work with something like:
     #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
     def hash
-      id = self.id
+      id = self.primary_key_value
 
       if primary_key_values_present? && !new_record?
         [self.class, id].hash

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -65,7 +65,7 @@ module ActiveRecord
           updates.merge!(touch_updates)
         end
 
-        unscoped.where(primary_key => object.id).update_all(updates) if updates.any?
+        unscoped.where(primary_key => object.primary_key_value).update_all(updates) if updates.any?
 
         true
       end
@@ -174,13 +174,13 @@ module ActiveRecord
 
     private
       def _create_record(attribute_names = self.attribute_names)
-        id = super
+        primary_key_value = super
 
         each_counter_cached_associations do |association|
           association.increment_counters
         end
 
-        id
+        primary_key_value
       end
 
       def destroy_row

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -80,9 +80,9 @@ module ActiveRecord
 
           if timestamp
             timestamp = timestamp.utc.to_fs(cache_timestamp_format)
-            "#{model_name.cache_key}/#{id}-#{timestamp}"
+            "#{model_name.cache_key}/#{primary_key_value}-#{timestamp}"
           else
-            "#{model_name.cache_key}/#{id}"
+            "#{model_name.cache_key}/#{primary_key_value}"
           end
         end
       end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -431,7 +431,7 @@ module ActiveRecord
         existing_record = send(association_name)
 
         if (options[:update_only] || !attributes["id"].blank?) && existing_record &&
-            (options[:update_only] || existing_record.id.to_s == attributes["id"].to_s)
+            (options[:update_only] || existing_record.primary_key_value.to_s == attributes["id"].to_s)
           assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
         elsif attributes["id"].present?
@@ -521,12 +521,12 @@ module ActiveRecord
             unless reject_new_record?(association_name, attributes)
               association.reader.build(attributes.except(*UNASSIGNABLE_KEYS))
             end
-          elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes["id"].to_s }
+          elsif existing_record = existing_records.detect { |record| record.primary_key_value.to_s == attributes["id"].to_s }
             unless call_reject_if(association_name, attributes)
               # Make sure we are operating on the actual object which is in the association's
               # proxy_target array (either by finding it, or adding it if not found)
               # Take into account that the proxy_target may have changed due to callbacks
-              target_record = association.target.detect { |record| record.id.to_s == attributes["id"].to_s }
+              target_record = association.target.detect { |record| record.primary_key_value.to_s == attributes["id"].to_s }
               if target_record
                 existing_record = target_record
               else

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -960,7 +960,7 @@ module ActiveRecord
     def increment!(attribute, by = 1, touch: nil)
       increment(attribute, by)
       change = public_send(attribute) - (public_send(:"#{attribute}_in_database") || 0)
-      self.class.update_counters(id, attribute => change, touch: touch)
+      self.class.update_counters(primary_key_value, attribute => change, touch: touch)
       public_send(:"clear_#{attribute}_change")
       self
     end
@@ -1151,7 +1151,7 @@ module ActiveRecord
 
     def _in_memory_query_constraints_hash
       if self.class.query_constraints_list.nil?
-        { @primary_key => id }
+        { @primary_key => primary_key_value }
       else
         self.class.query_constraints_list.index_with do |column_name|
           attribute(column_name)
@@ -1166,7 +1166,7 @@ module ActiveRecord
 
     def _query_constraints_hash
       if self.class.query_constraints_list.nil?
-        { @primary_key => id_in_database }
+        { @primary_key => primary_key_in_database }
       else
         self.class.query_constraints_list.index_with do |column_name|
           attribute_in_database(column_name)
@@ -1239,14 +1239,14 @@ module ActiveRecord
         attributes_with_values(attribute_names)
       )
 
-      self.id ||= new_id if @primary_key
+      self.primary_key_value ||= new_id if @primary_key
 
       @new_record = false
       @previously_new_record = true
 
       yield(self) if block_given?
 
-      id
+      primary_key_value
     end
 
     def verify_readonly_attribute(name)

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -236,7 +236,7 @@ module ActiveRecord
       loop do
         if load
           records = batch_relation.records
-          ids = records.map(&:id)
+          ids = records.map(&:primary_key_value)
           yielded_relation = where(primary_key => ids)
           yielded_relation.load_records(records)
         elsif (empty_scope && use_ranges != false) || use_ranges

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -489,7 +489,7 @@ module ActiveRecord
           if association
             key_ids     = calculated_data.collect { |row| row[group_aliases.first] }
             key_records = association.klass.base_class.where(association.klass.base_class.primary_key => key_ids)
-            key_records = key_records.index_by(&:id)
+            key_records = key_records.index_by(&:primary_key_value)
           end
 
           key_types = group_columns.each_with_object({}) do |(aliaz, col_name), types|

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -535,7 +535,7 @@ module ActiveRecord
         result = relation.records
 
         if result.size == ids.size
-          result.in_order_of(:id, ids.map { |id| @klass.type_for_attribute(primary_key).cast(id) })
+          result.in_order_of(:primary_key_value, ids.map { |id| @klass.type_for_attribute(primary_key).cast(id) })
         else
           raise_record_not_found_exception!(ids, result.size, ids.size)
         end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -55,7 +55,7 @@ module ActiveRecord
     end
 
     def build(attribute, value, operator = nil)
-      value = value.id if value.respond_to?(:id)
+      value = value.primary_key_value if value.respond_to?(:id)
       if operator ||= table.type(attribute.name).force_equality?(value) && :eq
         bind = build_bind_attribute(attribute.name, value)
         attribute.public_send(operator, bind)

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       def call(attribute, value)
         return attribute.in([]) if value.empty?
 
-        values = value.map { |x| x.is_a?(Base) ? x.id : x }
+        values = value.map { |x| x.is_a?(Base) ? x.primary_key_value : x }
         nils = values.extract!(&:nil?)
         ranges = values.extract! { |v| v.is_a?(Range) }
 

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -112,7 +112,7 @@ module ActiveRecord
     def signed_id(expires_in: nil, expires_at: nil, purpose: nil)
       raise ArgumentError, "Cannot get a signed_id for a new record" if new_record?
 
-      self.class.signed_id_verifier.generate id, expires_in: expires_in, expires_at: expires_at, purpose: self.class.combine_signed_id_purposes(purpose)
+      self.class.signed_id_verifier.generate primary_key_value, expires_in: expires_in, expires_at: expires_at, purpose: self.class.combine_signed_id_purposes(purpose)
     end
   end
 end

--- a/activerecord/lib/active_record/token_for.rb
+++ b/activerecord/lib/active_record/token_for.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       end
 
       def payload_for(model)
-        block ? [model.id, model.instance_eval(&block).as_json] : [model.id]
+        block ? [model.primary_key_value, model.instance_eval(&block).as_json] : [model.primary_key_value]
       end
 
       def generate_token(model)

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -386,7 +386,7 @@ module ActiveRecord
       # Save the new record state and id of a record so it can be restored later if a transaction fails.
       def remember_transaction_record_state
         @_start_transaction_state ||= {
-          id: id,
+          id: primary_key_value,
           new_record: @new_record,
           previously_new_record: @previously_new_record,
           destroyed: @destroyed,

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         relation = build_relation(finder_class, attribute, value)
         if record.persisted?
           if finder_class.primary_key
-            relation = relation.where.not(finder_class.primary_key => record.id_in_database)
+            relation = relation.where.not(finder_class.primary_key => record.primary_key_in_database)
           else
             raise UnknownPrimaryKey.new(finder_class, "Cannot validate uniqueness for persisted record without primary key.")
           end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -74,7 +74,7 @@ module ActiveRecord
         result = Owner.connection.exec_query <<~SQL
           SELECT #{select}
           FROM   #{Owner.table_name}
-          WHERE  #{Owner.primary_key} = #{owner.id}
+          WHERE  #{Owner.primary_key} = #{owner.primary_key_value}
         SQL
 
         assert_not(result.rows.first.include?("blob"), "should not store blobs")
@@ -455,7 +455,7 @@ module ActiveRecord
 
         connection.remove_column("barcodes", "other_attr")
 
-        assert_equal code, Barcode.first.id
+        assert_equal code, Barcode.first.primary_key_value
       ensure
         Barcode.reset_column_information
       end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -558,13 +558,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_load_has_many_with_string_keys
     subscriptions = subscriptions(:webster_awdr, :webster_rfr)
-    subscriber = Subscriber.all.merge!(includes: :subscriptions).find(subscribers(:second).id)
+    subscriber = Subscriber.all.merge!(includes: :subscriptions).find(subscribers(:second).primary_key_value)
     assert_equal subscriptions, subscriber.subscriptions.sort_by(&:id)
   end
 
   def test_string_id_column_joins
     s = Subscriber.create! do |c|
-      c.id = "PL"
+      c.primary_key_value = "PL"
     end
 
     b = Book.create!
@@ -576,7 +576,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_load_has_many_through_with_string_keys
     books = books(:awdr, :rfr)
-    subscriber = Subscriber.all.merge!(includes: :books).find(subscribers(:second).id)
+    subscriber = Subscriber.all.merge!(includes: :books).find(subscribers(:second).primary_key_value)
     assert_equal books, subscriber.books.sort_by(&:id)
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2789,7 +2789,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   test "does not duplicate associations when used with natural primary keys" do
-    speedometer = Speedometer.create!(id: "4")
+    speedometer = Speedometer.create!(primary_key_value: "4")
     speedometer.minivans.create!(minivan_id: "a-van-red", name: "a van", color: "red")
 
     assert_equal 1, speedometer.minivans.to_a.size, "Only one association should be present:\n#{speedometer.minivans.to_a}"
@@ -2802,9 +2802,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     bulb2 = Bulb.create! name: "other",    car: car
 
     assert_equal [bulb1], car.bulbs
-    assert_equal [bulb1, bulb2], car.all_bulbs.sort_by(&:id)
-    assert_equal [bulb1, bulb2], Car.includes(:all_bulbs).find(car.id).all_bulbs.sort_by(&:id)
-    assert_equal [bulb1, bulb2], Car.eager_load(:all_bulbs).find(car.id).all_bulbs.sort_by(&:id)
+    assert_equal [bulb1, bulb2], car.all_bulbs.sort_by(&:primary_key_value)
+    assert_equal [bulb1, bulb2], Car.includes(:all_bulbs).find(car.primary_key_value).all_bulbs.sort_by(&:primary_key_value)
+    assert_equal [bulb1, bulb2], Car.eager_load(:all_bulbs).find(car.primary_key_value).all_bulbs.sort_by(&:primary_key_value)
   end
 
   test "can unscope and where the default scope of the associated model" do
@@ -2830,8 +2830,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     bulb1 = Bulb.create! name: "defaulty", car: car
     bulb2 = Bulb.create! name: "other",    car: car
 
-    assert_equal [bulb1, bulb2], Car.includes(:all_bulbs2).find(car.id).all_bulbs2.sort_by(&:id)
-    assert_equal [bulb1, bulb2], Car.eager_load(:all_bulbs2).find(car.id).all_bulbs2.sort_by(&:id)
+    assert_equal [bulb1, bulb2], Car.includes(:all_bulbs2).find(car.id).all_bulbs2.sort_by(&:primary_key_value)
+    assert_equal [bulb1, bulb2], Car.eager_load(:all_bulbs2).find(car.id).all_bulbs2.sort_by(&:primary_key_value)
   end
 
   test "raises RecordNotDestroyed when replaced child can't be destroyed" do
@@ -2843,7 +2843,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal [original_child], car.reload.failed_bulbs
-    assert_equal "Failed to destroy FailedBulb with #{FailedBulb.primary_key}=#{original_child.id}", error.message
+    assert_equal "Failed to destroy FailedBulb with #{FailedBulb.primary_key}=#{original_child.primary_key_value}", error.message
   end
 
   test "updates counter cache when default scope is given" do
@@ -2904,7 +2904,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [nil, "honda"], car.saved_change_to_name
 
-    new_bulb = Bulb.find(bulb.id)
+    new_bulb = Bulb.find(bulb.primary_key_value)
     new_bulb.name = "foo"
     car.bulbs = [new_bulb]
 
@@ -2917,7 +2917,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [nil, "honda"], car.saved_change_to_name
 
-    new_bulb = Bulb.find(bulb.id)
+    new_bulb = Bulb.find(bulb.primary_key_value)
 
     assert_no_queries do
       car.bulbs = [new_bulb]
@@ -2937,7 +2937,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     bulb = Bulb.create!
     car = klass.create!(bulbs: [bulb])
 
-    new_bulb = Bulb.find(bulb.id)
+    new_bulb = Bulb.find(bulb.primary_key_value)
     raise_after_add = true
 
     assert_nothing_raised do
@@ -2951,7 +2951,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [nil, "honda"], car.saved_change_to_name
 
-    new_bulb = Bulb.find(bulb.id)
+    new_bulb = Bulb.find(bulb.primary_key_value)
     car.bulbs = [new_bulb]
 
     assert_same car, new_bulb.car
@@ -2973,7 +2973,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [nil, "honda"], car.saved_change_to_name
 
-    same_bulb = Bulb.find(first_bulb.id)
+    same_bulb = Bulb.find(first_bulb.primary_key_value)
     car.bulbs = [second_bulb, same_bulb]
 
     assert_equal [first_bulb, second_bulb], car.bulbs
@@ -3108,12 +3108,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     car = Car.create!(name: "Tofaş")
     bulb = Bulb.create!(car: car)
 
-    assert_equal [bulb.id], car.bulb_ids
+    assert_equal [bulb.primary_key_value], car.bulb_ids
     assert_no_queries { car.bulb_ids }
 
     bulb2 = car.bulbs.create!
 
-    assert_equal [bulb.id, bulb2.id], car.bulb_ids
+    assert_equal [bulb.primary_key_value, bulb2.primary_key_value], car.bulb_ids
     assert_no_queries { car.bulb_ids }
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -150,8 +150,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     anonbook.subscribers.each do |s|
       assert_instance_of subscriber, s
     end
-    assert_equal namebook.subscribers.map(&:id).sort,
-                 anonbook.subscribers.map(&:id).sort
+    assert_equal namebook.subscribers.map(&:primary_key_value).sort,
+                 anonbook.subscribers.map(&:primary_key_value).sort
   end
 
   def test_no_pk_join_table_append

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -376,7 +376,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate proxy, :stale_target?
     assert_equal dashboards(:cool_first), minivan.dashboard
 
-    minivan.speedometer_id = speedometers(:second).id
+    minivan.speedometer_id = speedometers(:second).primary_key_value
 
     assert_predicate proxy, :stale_target?
     assert_equal dashboards(:second), minivan.dashboard
@@ -388,7 +388,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     minivan.dashboard
     proxy = minivan.send(:association_instance_get, :dashboard)
 
-    minivan.speedometer_id = speedometers(:second).id
+    minivan.speedometer_id = speedometers(:second).primary_key_value
 
     assert_predicate proxy, :stale_target?
     assert_equal dashboards(:second), minivan.dashboard

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -499,7 +499,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_raises(ActiveRecord::HasManyThroughNestedAssociationsAreReadonly) do
-      david.subscriber_ids = [subscriber.id]
+      david.subscriber_ids = [subscriber.primary_key_value]
     end
 
     assert_raises(ActiveRecord::HasManyThroughNestedAssociationsAreReadonly) do

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -140,7 +140,7 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_belongs_to_a_cpk_model_by_id_attribute
     order = cpk_orders(:cpk_groceries_order_1)
-    _order_shop_id, order_id = order.id
+    _order_shop_id, order_id = order.primary_key_value
     agreement = Cpk::OrderAgreement.create(order_id: order_id, signature: "signed")
 
     assert_equal(order, agreement.order)
@@ -176,7 +176,7 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_cpk_model_has_many_records_by_id_attribute
     order = cpk_orders(:cpk_groceries_order_1)
-    _order_shop_id, order_id = order.id
+    _order_shop_id, order_id = order.primary_key_value
     agreements = 2.times.map { Cpk::OrderAgreement.create(order_id: order_id, signature: "signed") }
 
     assert_equal(agreements.sort, order.order_agreements.to_a.sort)
@@ -299,7 +299,7 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_not_nil(agreement.order_id)
 
     assert_equal(order, agreement.order)
-    _shop_id, order_id = order.id
+    _shop_id, order_id = order.primary_key_value
     assert_equal(order_id, agreement.order_id)
   end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -128,7 +128,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "integers as nil" do
     test = AutoId.create(value: "")
-    assert_nil AutoId.find(test.id).value
+    assert_nil AutoId.find(test.primary_key_value).value
   end
 
   test "set attributes with a block" do
@@ -158,15 +158,15 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "respond_to? with a custom primary key" do
     keyboard = Keyboard.create
     assert_not_nil keyboard.key_number
-    assert_equal keyboard.key_number, keyboard.id
+    assert_equal keyboard.key_number, keyboard.primary_key_value
     assert_respond_to keyboard, "key_number"
     assert_respond_to keyboard, "id"
   end
 
-  test "id_before_type_cast with a custom primary key" do
+  test "primary_key_before_type_cast with a custom primary key" do
     keyboard = Keyboard.create
     keyboard.key_number = "10"
-    assert_equal "10", keyboard.id_before_type_cast
+    assert_equal "10", keyboard.primary_key_before_type_cast
     assert_nil keyboard.read_attribute_before_type_cast("id")
     assert_equal "10", keyboard.read_attribute_before_type_cast("key_number")
     assert_equal "10", keyboard.read_attribute_before_type_cast(:key_number)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -747,7 +747,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   end
 
   def test_assign_ids_with_cpk_for_two_models
-    books = [cpk_books(:cpk_great_author_first_book).id, cpk_books(:cpk_great_author_second_book).id]
+    books = [cpk_books(:cpk_great_author_first_book).primary_key_value, cpk_books(:cpk_great_author_second_book).primary_key_value]
     order = cpk_orders(:cpk_groceries_order_1)
 
     assert_empty order.books

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -333,7 +333,7 @@ class BasicsTest < ActiveRecord::TestCase
       with_timezone_config aware_attributes: true, default: :utc, zone: "UTC" do
         pet = Pet.create(name: "Bidu")
         assert_predicate pet, :persisted?
-        saved_pet = Pet.find(pet.id)
+        saved_pet = Pet.find(pet.primary_key_value)
         assert_not_nil saved_pet.created_at
         assert_not_nil saved_pet.updated_at
       end
@@ -1212,7 +1212,7 @@ class BasicsTest < ActiveRecord::TestCase
   def test_auto_id
     auto = AutoId.new
     auto.save
-    assert(auto.id > 0)
+    assert(auto.primary_key_value > 0)
   end
 
   def test_sql_injection_via_find

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -265,7 +265,7 @@ class EachTest < ActiveRecord::TestCase
       subscribers.concat(batch)
     end
 
-    assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
+    assert_equal nick_order_subscribers[1..-1].map(&:primary_key_value), subscribers.map(&:primary_key_value)
   end
 
   def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
@@ -569,7 +569,7 @@ class EachTest < ActiveRecord::TestCase
       subscribers.concat(relation)
     end
 
-    assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
+    assert_equal nick_order_subscribers[1..-1].map(&:primary_key_value), subscribers.map(&:primary_key_value)
   end
 
   def test_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
@@ -780,19 +780,19 @@ class EachTest < ActiveRecord::TestCase
 
   test ".in_batches should start from the start option when using composite primary key" do
     order = Cpk::Order.second
-    relation = Cpk::Order.in_batches(of: 1, start: order.id).first
+    relation = Cpk::Order.in_batches(of: 1, start: order.primary_key_value).first
     assert_equal order, relation.first
   end
 
   test ".in_batches should end at the finish option when using composite primary key" do
     order = Cpk::Order.second_to_last
-    relation = Cpk::Order.in_batches(of: 1, finish: order.id).reverse_each.first
+    relation = Cpk::Order.in_batches(of: 1, finish: order.primary_key_value).reverse_each.first
     assert_equal order, relation.last
   end
 
   test ".in_batches with scope and using composite primary key" do
     order1, order2 = Cpk::Order.first(2)
-    shop_id, id = order1.id
+    shop_id, id = order1.primary_key_value
     relation = Cpk::Order.where("shop_id > ? OR shop_id = ? AND id > ?", shop_id, shop_id, id).in_batches(of: 1).first
     assert_equal order2, relation.first
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -487,8 +487,8 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_association_with_non_numeric_foreign_key
-    Speedometer.create! id: "ABC"
-    Minivan.create! id: "OMG", speedometer_id: "ABC"
+    Speedometer.create! primary_key_value: "ABC"
+    Minivan.create! primary_key_value: "OMG", speedometer_id: "ABC"
 
     c = Minivan.group(:speedometer).count(:all)
     first_key = c.keys.first
@@ -942,7 +942,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_ids_for_a_composite_primary_key
-    assert_equal Cpk::Book.all.map(&:id).sort, Cpk::Book.all.ids.sort
+    assert_equal Cpk::Book.all.map(&:primary_key_value).sort, Cpk::Book.all.ids.sort
   end
 
   def test_pluck_for_a_composite_primary_key

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -182,11 +182,11 @@ class CounterCacheTest < ActiveRecord::TestCase
 
   test "reset counter of has_many :through association" do
     subscriber = subscribers("second")
-    Subscriber.reset_counters(subscriber.id, "books")
-    Subscriber.increment_counter("books_count", subscriber.id)
+    Subscriber.reset_counters(subscriber.primary_key_value, "books")
+    Subscriber.increment_counter("books_count", subscriber.primary_key_value)
 
     assert_difference "subscriber.reload.books_count", -1 do
-      Subscriber.reset_counters(subscriber.id, "books")
+      Subscriber.reset_counters(subscriber.primary_key_value, "books")
     end
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -245,8 +245,8 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal false, Subscriber.exists?("foo")
     assert_equal false, Subscriber.exists?("   ")
 
-    Subscriber.create!(id: "foo")
-    Subscriber.create!(id: "   ")
+    Subscriber.create!(primary_key_value: "foo")
+    Subscriber.create!(primary_key_value: "   ")
 
     assert_equal true, Subscriber.exists?("foo")
     assert_equal true, Subscriber.exists?("   ")
@@ -1785,33 +1785,33 @@ class FinderTest < ActiveRecord::TestCase
   test "#find with a single composite primary key" do
     book = cpk_books(:cpk_great_author_first_book)
 
-    assert_equal book, Cpk::Book.find(book.id)
+    assert_equal book, Cpk::Book.find(book.primary_key_value)
   end
 
   test "find with a single composite primary key wrapped in an array" do
     book = cpk_books(:cpk_great_author_first_book)
 
-    assert_equal [book], Cpk::Book.find([book.id])
+    assert_equal [book], Cpk::Book.find([book.primary_key_value])
   end
 
   test "find with a multiple sets of composite primary key" do
     books = [cpk_books(:cpk_great_author_first_book), cpk_books(:cpk_great_author_second_book)]
-    ids = books.map(&:id)
+    ids = books.map(&:primary_key_value)
     result = Cpk::Book.find(*ids)
 
-    assert_equal ids, result.map(&:id)
+    assert_equal ids, result.map(&:primary_key_value)
   end
 
   test "find with a multiple sets of composite primary key wrapped in an array" do
     books = [cpk_books(:cpk_great_author_first_book), cpk_books(:cpk_great_author_second_book)]
 
-    assert_equal books.map(&:id), Cpk::Book.where(revision: 1).find(books.map(&:id)).map(&:id)
+    assert_equal books.map(&:primary_key_value), Cpk::Book.where(revision: 1).find(books.map(&:primary_key_value)).map(&:primary_key_value)
   end
 
   test "find with a multiple sets of composite primary key wrapped in an array ordered" do
     books = [cpk_books(:cpk_great_author_first_book), cpk_books(:cpk_great_author_second_book)]
 
-    assert_equal books.map(&:id), Cpk::Book.order(author_id: :asc).find(books.map(&:id)).map(&:id)
+    assert_equal books.map(&:primary_key_value), Cpk::Book.order(author_id: :asc).find(books.map(&:primary_key_value)).map(&:primary_key_value)
   end
 
   private

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1649,20 +1649,20 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
       alice = cpk_authors(:cpk_great_author)
       alice_cpk_book = cpk_books(:cpk_great_author_first_book)
 
-      assert_not_empty(alice_cpk_book.id.compact)
+      assert_not_empty(alice_cpk_book.primary_key_value.compact)
       assert_equal alice.id, alice_cpk_book.author_id
       assert_not_nil alice_cpk_book.number
     end
 
     def test_generates_composite_primary_key_ids
-      assert_not_empty(cpk_orders(:cpk_groceries_order_1).id.compact)
+      assert_not_empty(cpk_orders(:cpk_groceries_order_1).primary_key_value.compact)
 
       assert_not_nil(cpk_books(:cpk_great_author_first_book).author_id)
       assert_not_nil(cpk_books(:cpk_great_author_first_book).number)
     end
 
     def test_generates_composite_primary_key_with_unique_components
-      assert_equal 2, cpk_orders(:cpk_groceries_order_1).id.uniq.size
+      assert_equal 2, cpk_orders(:cpk_groceries_order_1).primary_key_value.uniq.size
     end
 
     def test_resolves_associations_using_composite_primary_keys

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -490,7 +490,7 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_inheritance_without_mapping
     assert_kind_of SpecialSubscriber, SpecialSubscriber.find("webster132")
-    assert_nothing_raised { s = SpecialSubscriber.new("name" => "And breaaaaathe!"); s.id = "roger"; s.save }
+    assert_nothing_raised { s = SpecialSubscriber.new("name" => "And breaaaaathe!"); s.primary_key_value = "roger"; s.save }
   end
 
   def test_scope_inherited_properly

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -309,7 +309,7 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_modify_an_existing_record_if_there_is_a_matching_composite_id
-    @ship.stub(:id, "ABC1X") do
+    @ship.stub(:primary_key_value, "ABC1X") do
       @pirate.ship_attributes = { id: @ship.id, name: "Davy Jones Gold Dagger" }
 
       assert_equal "Davy Jones Gold Dagger", @pirate.ship.name
@@ -493,7 +493,7 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_modify_an_existing_record_if_there_is_a_matching_composite_id
-    @pirate.stub(:id, "ABC1X") do
+    @pirate.stub(:primary_key_value, "ABC1X") do
       @ship.pirate_attributes = { id: @pirate.id, catchphrase: "Arr" }
 
       assert_equal "Arr", @ship.pirate.catchphrase
@@ -681,8 +681,8 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   def test_should_take_a_hash_with_composite_id_keys_and_assign_the_attributes_to_the_associated_models
-    @child_1.stub(:id, "ABC1X") do
-      @child_2.stub(:id, "ABC2X") do
+    @child_1.stub(:primary_key_value, "ABC1X") do
+      @child_2.stub(:primary_key_value, "ABC2X") do
         @pirate.attributes = {
           association_getter => [
             { id: @child_1.id, name: "Grace OMalley" },
@@ -971,8 +971,8 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
 
     @params = {
       pets_attributes: {
-        "0" => { id: @pet1.id, name: "Foo" },
-        "1" => { id: @pet2.id, name: "Bar" }
+        "0" => { id: @pet1.primary_key_value, name: "Foo" },
+        "1" => { id: @pet2.primary_key_value, name: "Bar" }
       }
     }
   end
@@ -985,7 +985,7 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
   def test_attr_accessor_of_child_should_be_value_provided_during_update
     @owner = owners(:ashley)
     @pet1 = pets(:chew)
-    attributes = { pets_attributes: { "1" => { id: @pet1.id,
+    attributes = { pets_attributes: { "1" => { id: @pet1.primary_key_value,
                                                 name: "Foo2",
                                                 current_user: "John",
                                                 _destroy: true } } }

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -296,7 +296,7 @@ class PersistenceTest < ActiveRecord::TestCase
     book = cpk_books(:cpk_great_author_first_book)
 
     assert_difference("Cpk::Book.count", -1) do
-      destroyed = Cpk::Book.destroy(book.id)
+      destroyed = Cpk::Book.destroy(book.primary_key_value)
       assert_equal destroyed, book
     end
   end
@@ -308,7 +308,7 @@ class PersistenceTest < ActiveRecord::TestCase
     ]
 
     assert_difference("Cpk::Book.count", -2) do
-      destroyed = Cpk::Book.destroy(books.map(&:id))
+      destroyed = Cpk::Book.destroy(books.map(&:primary_key_value))
       assert_equal books.sort, destroyed.sort
       assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
     end
@@ -321,7 +321,7 @@ class PersistenceTest < ActiveRecord::TestCase
     ]
 
     assert_raise(ActiveRecord::RecordNotFound) do
-      ids = books.map { |book| book.id.first }
+      ids = books.map { |book| book.primary_key_value.first }
       Cpk::Book.destroy(ids)
     end
   end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -26,7 +26,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     keyboard = Keyboard.new
     assert_nil keyboard.to_key
     keyboard.save
-    assert_equal keyboard.to_key, [keyboard.id]
+    assert_equal keyboard.to_key, [keyboard.primary_key_value]
   end
 
   def test_read_attribute_with_custom_primary_key
@@ -41,7 +41,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 
   def test_read_attribute_with_composite_primary_key_and_column_named_id
     order = Cpk::Order.new
-    order.id = [1, 2]
+    order.primary_key_value = [1, 2]
 
     assert_equal [1, 2], order.read_attribute(:id)
     assert_equal 2, order.attributes["id"]
@@ -73,19 +73,19 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     Keyboard.delete_all
     keyboard = Keyboard.new(name: "HHKB")
     keyboard.save!
-    assert_equal keyboard.id, Keyboard.find_by_name("HHKB").id
+    assert_equal keyboard.primary_key_value, Keyboard.find_by_name("HHKB").primary_key_value
   end
 
   def test_customized_primary_key_can_be_get_before_saving
     keyboard = Keyboard.new
-    assert_nil keyboard.id
+    assert_nil keyboard.primary_key_value
     assert_nil keyboard.key_number
   end
 
   def test_customized_string_primary_key_settable_before_save
     subscriber = Subscriber.new
-    subscriber.id = "webster123"
-    assert_equal "webster123", subscriber.id
+    subscriber.primary_key_value = "webster123"
+    assert_equal "webster123", subscriber.primary_key_value
     assert_equal "webster123", subscriber.nick
   end
 
@@ -109,11 +109,11 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal(subscribers(:second).name, subscriber.name)
 
     subscriber = Subscriber.new
-    subscriber.id = "jdoe"
-    assert_equal("jdoe", subscriber.id)
+    subscriber.primary_key_value = "jdoe"
+    assert_equal("jdoe", subscriber.primary_key_value)
     subscriber.name = "John Doe"
     subscriber.save!
-    assert_equal("jdoe", subscriber.id)
+    assert_equal("jdoe", subscriber.primary_key_value)
 
     subscriberReloaded = Subscriber.find("jdoe")
     assert_equal("John Doe", subscriberReloaded.name)
@@ -201,11 +201,11 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 
   def test_primary_key_update_with_custom_key_name
     dashboard = Dashboard.create!(dashboard_id: "1")
-    dashboard.id = "2"
+    dashboard.primary_key_value = "2"
     dashboard.save!
 
     dashboard = Dashboard.first
-    assert_equal "2", dashboard.id
+    assert_equal "2", dashboard.primary_key_value
   end
 
   def test_create_without_primary_key_no_extra_query
@@ -223,7 +223,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
       self.table_name = "dashboards"
     end
     dashboard = klass.new
-    assert_raises(ActiveModel::MissingAttributeError) { dashboard.id = "1" }
+    assert_raises(ActiveModel::MissingAttributeError) { dashboard.primary_key_value = "1" }
   end
 
   def composite_primary_key_is_false_for_a_non_cpk_model
@@ -395,10 +395,10 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 
   def test_assigning_a_composite_primary_key
     book = Cpk::Book.new
-    book.id = [1, 2]
+    book.primary_key_value = [1, 2]
     book.save!
 
-    assert_equal [1, 2], book.id
+    assert_equal [1, 2], book.primary_key_value
     assert_equal 1, book.author_id
     assert_equal 2, book.number
   ensure
@@ -409,7 +409,7 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
     book = Cpk::Book.new
 
     assert_raises(TypeError) do
-      book.id = 1
+      book.primary_key_value = 1
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -35,7 +35,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_do_not_double_quote_string_id
     van = Minivan.last
     assert van
-    assert_equal van.id, Minivan.where(minivan_id: van).to_a.first.minivan_id
+    assert_equal van.primary_key_value, Minivan.where(minivan_id: van).to_a.first.minivan_id
   end
 
   def test_do_not_double_quote_string_id_with_array
@@ -948,7 +948,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_all_using_where_with_relation_with_no_selects_and_composite_primary_key_raises
     order = cpk_orders(:cpk_groceries_order_1)
-    subquery = Cpk::Order.where(Cpk::Order.primary_key => [order.id])
+    subquery = Cpk::Order.where(Cpk::Order.primary_key => [order.primary_key_value])
 
     assert_nothing_raised do
       Cpk::Order.where(id: subquery.select(:id)).to_a

--- a/activerecord/test/cases/reserved_word_test.rb
+++ b/activerecord/test/cases/reserved_word_test.rb
@@ -98,7 +98,7 @@ class ReservedWordTest < ActiveRecord::TestCase
   def test_has_one_associations
     create_test_fixtures :group, :values
     v = Group.find(1).values
-    assert_equal 2, v.id
+    assert_equal 2, v.primary_key_value
   end
 
   def test_belongs_to_associations

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -935,7 +935,7 @@ class TransactionTest < ActiveRecord::TestCase
       raise ActiveRecord::Rollback
     end
 
-    assert_equal [1, 2], book.id
+    assert_equal [1, 2], book.primary_key_value
   ensure
     Cpk::Book.delete_all
   end

--- a/activerecord/test/cases/validations/length_validation_test.rb
+++ b/activerecord/test/cases/validations/length_validation_test.rb
@@ -56,7 +56,7 @@ class LengthValidationTest < ActiveRecord::TestCase
     assert owner.save
 
     pet_count = Pet.count
-    assert_not owner.update pets_attributes: [ { _destroy: 1, id: pet.id } ]
+    assert_not owner.update pets_attributes: [ { _destroy: 1, id: pet.primary_key_value } ]
     assert_not_predicate owner, :valid?
     assert_predicate owner.errors[:pets], :any?
     assert_equal pet_count, Pet.count

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -285,6 +285,7 @@ module Rails
             active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
             active_record.marshalling_format_version = 7.1
             active_record.run_after_transaction_callbacks_in_order_defined = true
+            active_record.use_id_as_attribute = false
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -166,3 +166,8 @@
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 # Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+
+# Use the `id` column as an attribute when an application has a custom primary key.
+# Most applications can optin automatically and no changes will be required. If you are using
+# a custom primary key, you'll need to update the callers to use the new primary key methods.
+# Rails.application.config.active_record.use_id_as_attribute = true


### PR DESCRIPTION
During our work on composite keys in Rails it became clear that we were conflating the meaning of `id`. In most cases applications use the `id` column as the primary key. However Rails allows you to set a custom primary key and use `id` to call that. For example if `Post` has a primary key named `title` calling `Post.first.id` will return the title, even if there is an `id` column on the posts table.

Essenstially the problem is that by treating `id` as special there is no good API for accessing or setting an `id` attribute on a record with a custom primary key.

This PR proposes removing the special meaning for `id`. If an application is using a standard `id` column as the primary key, no changes will be required. If an application does have a custom primary key Rails will fire a deprecation warning and point them to use the `primary_key_*` methods instead. This will also be useful for composite primary keys becasue it's likely many applications will use keys like `[:shop_id, :id]`. Without this change the only way to access the actual id attribute would be `post.attributes["id"]` or
`post._read_attribute("id")`. With this change applications can access the full key with `post.primary_key_value` or just the `id` attribute with `post.id`.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
